### PR TITLE
changes to the intra-layer API for the GPT benchmark

### DIFF
--- a/.github/workflows/nvidia-tests.yaml
+++ b/.github/workflows/nvidia-tests.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ develop ]
 
 jobs:
-  mnist-trainer:
+  inter-layer:
     runs-on: [ nvidia ]
 
     strategy:
@@ -28,7 +28,22 @@ jobs:
         export G_data=$(( 2 / G_inter ))
         export memopt=${{ matrix.memopt }}
         echo "training with G_inter = ${G_inter}, G_data = $(( 2 / G_inter  )) ${{ matrix.memopt }}" 
-        mpirun -n 2 pytest --with-mpi 
+        mpirun -n 2 pytest --with-mpi ./tests/test_vit.py 
+    - name: Uninstall AxoNN
+      run: |
+        pip uninstall --yes axonn
+
+
+  intra-layer:
+    runs-on: [ nvidia ]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install AxoNN
+      run: |
+        pip install -r requirements.txt
+    - name: Run unit intra-layer unit tests 
+      run: |
+        mpirun -n 2 pytest --with-mpi ./tests/test_intra_layer_fc.py 
     - name: Uninstall AxoNN
       run: |
         pip uninstall --yes axonn

--- a/.github/workflows/nvidia-tests.yaml
+++ b/.github/workflows/nvidia-tests.yaml
@@ -28,7 +28,7 @@ jobs:
         export G_data=$(( 2 / G_inter ))
         export memopt=${{ matrix.memopt }}
         echo "training with G_inter = ${G_inter}, G_data = $(( 2 / G_inter  )) ${{ matrix.memopt }}" 
-        mpirun -n 2 pytest --with-mpi test_vit.py 
+        mpirun -n 2 pytest --with-mpi ./axonn/tests/test_vit.py 
     - name: Uninstall AxoNN
       run: |
         pip uninstall --yes axonn
@@ -43,7 +43,7 @@ jobs:
         pip install -r requirements.txt
     - name: Run unit intra-layer unit tests 
       run: |
-        mpirun -n 2 pytest --with-mpi test_intra_layer_fc.py 
+        mpirun -n 2 pytest --with-mpi ./axonn/tests/test_intra_layer_fc.py 
     - name: Uninstall AxoNN
       run: |
         pip uninstall --yes axonn

--- a/.github/workflows/nvidia-tests.yaml
+++ b/.github/workflows/nvidia-tests.yaml
@@ -28,7 +28,7 @@ jobs:
         export G_data=$(( 2 / G_inter ))
         export memopt=${{ matrix.memopt }}
         echo "training with G_inter = ${G_inter}, G_data = $(( 2 / G_inter  )) ${{ matrix.memopt }}" 
-        mpirun -n 2 pytest --with-mpi ./tests/test_vit.py 
+        mpirun -n 2 pytest --with-mpi test_vit.py 
     - name: Uninstall AxoNN
       run: |
         pip uninstall --yes axonn
@@ -43,7 +43,7 @@ jobs:
         pip install -r requirements.txt
     - name: Run unit intra-layer unit tests 
       run: |
-        mpirun -n 2 pytest --with-mpi ./tests/test_intra_layer_fc.py 
+        mpirun -n 2 pytest --with-mpi test_intra_layer_fc.py 
     - name: Uninstall AxoNN
       run: |
         pip uninstall --yes axonn

--- a/axonn/communication.py
+++ b/axonn/communication.py
@@ -205,11 +205,3 @@ class communication_handle:
         mpi4py_compatible_array = self._torch_to_mpi(tensor)
         self.p2p_mpi_comm.Bcast(mpi4py_compatible_array, root=root)
 
-    def get_tensor_model_parallel_rank(self):
-        return self.intra_layer_parallel_rank
-
-    def get_tensor_model_parallel_world_size(self):
-        return self.G_intra
-
-    def get_tensor_model_parallel_group(self):
-        return self.intra_layer_group

--- a/axonn/communication.py
+++ b/axonn/communication.py
@@ -204,4 +204,3 @@ class communication_handle:
     def broadcast_inter_layer(self, tensor, root):
         mpi4py_compatible_array = self._torch_to_mpi(tensor)
         self.p2p_mpi_comm.Bcast(mpi4py_compatible_array, root=root)
-

--- a/axonn/intra_layer/communication.py
+++ b/axonn/intra_layer/communication.py
@@ -25,7 +25,7 @@ def _gather(input_, dim, process_group=None):
     """Gather tensors and concatenate them along a dimension"""
     if dist.get_world_size(process_group) == 1:
         return input_
-    
+
     input_ = input_.contiguous()
     # Size and dimension.
     rank = dist.get_rank(process_group)

--- a/axonn/intra_layer/fully_connected.py
+++ b/axonn/intra_layer/fully_connected.py
@@ -3,9 +3,25 @@ import torch.distributed as dist
 import torch
 from .communication import ForwardAllReduce, BackwardAllReduce, Drop
 
+def divide(a, b):
+    assert a%b == 0
+    return a//b
+
+@torch.no_grad()
+def initialize_params(out_features, in_features, 
+                      out_features_group, in_features_group, 
+                      init_method):
+    params = torch.empty((out_features, in_features))
+    init_method(params)
+    params = Drop.apply(torch.t(params).contiguous(), out_features_group)
+    params = torch.t(params).contiguous()
+    params = Drop.apply(params, in_features_group)
+    return params
 
 class Linear(torch.nn.Module):
-    def __init__(self, in_features, out_features, *args, transpose=False, **kwargs):
+    def __init__(self, in_features, out_features, 
+                 *args, transpose=False, skip_bias_add=False, 
+                 init_method=None, **kwargs):
         super(Linear, self).__init__()
         self.inner_group = ax.comm_handle.inner_intra_layer_parallel_group
         self.outer_group = ax.comm_handle.outer_intra_layer_parallel_group
@@ -16,25 +32,41 @@ class Linear(torch.nn.Module):
         if not transpose:
             assert in_features % self.inner_group_size == 0
             assert out_features % self.outer_group_size == 0
-            self.local_in_features = in_features // self.inner_group_size
-            self.linear = torch.nn.Linear(
-                in_features=in_features // self.inner_group_size,
-                out_features=out_features // self.outer_group_size,
-                *args,
-                **kwargs,
-            )
+            self.local_in_features = divide(in_features, self.inner_group_size)
+            self.local_out_features = divide(out_features, self.outer_group_size)
+            if init_method:
+                initial_params = initialize_params(out_features, 
+                                              in_features, 
+                                              self.outer_group, 
+                                              self.inner_group, init_method)
         else:
             assert out_features % self.inner_group_size == 0
             assert in_features % self.outer_group_size == 0
-            self.local_in_features = in_features // self.outer_group_size
-            self.linear = torch.nn.Linear(
-                in_features=in_features // self.outer_group_size,
-                out_features=out_features // self.inner_group_size,
-                *args,
-                **kwargs,
-            )
+            self.local_in_features = divide(in_features, self.outer_group_size)
+            self.local_out_features = divide(out_features, self.inner_group_size)
+            if init_method:
+                initial_params = initialize_params(out_features, 
+                                              in_features, 
+                                              self.inner_group, 
+                                              self.outer_group, init_method)
 
+        self.linear = torch.nn.Linear(
+            in_features=self.local_in_features,
+            out_features=self.local_out_features,
+            *args,
+            **kwargs,
+            bias=False
+        )
+        
+        if init_method:
+            self.linear.weight.data.copy_(initial_params)
+
+        self.bias = torch.nn.Parameter(torch.zeros(self.local_out_features,))
         self.transpose = transpose
+        self.skip_bias_add = skip_bias_add
+
+    def get_output_feature_size(self):
+        return self.local_out_features
 
     def forward(self, x):
         if not self.transpose:
@@ -49,4 +81,8 @@ class Linear(torch.nn.Module):
             x = BackwardAllReduce.apply(x, self.inner_group)
             x = self.linear(x)
             x = ForwardAllReduce.apply(x, self.outer_group)
-        return x
+
+        if self.skip_bias_add:
+            return x, self.bias
+        else:
+            return x + self.bias


### PR DESCRIPTION
1. add functionality to initialize weights using a custom user-defined function
2. make communication no-ops when group size is 1
3. remove dead code in axonn/communication.py
4. refactor intra-layer unit tests to be compatible with the latest API
5. refactor the unit test workflow to separate inter-layer and intra-layer tests