### PR TITLE
add option to change batch dimension in drop

### DIFF
--- a/axonn/intra_layer/__init__.py
+++ b/axonn/intra_layer/__init__.py
@@ -7,23 +7,23 @@ from .gradient_normalization import clip_grad_norm_  # noqa: F401
 from axonn import axonn as ax
 
 
-def drop(x, transpose=False, dim=-1):
+def drop(x, transpose=False, dim=-1, batch_dim=0):
     if not transpose:
         group = ax.comm_handle.inner_intra_layer_parallel_group
     else:
         group = ax.comm_handle.outer_intra_layer_parallel_group
 
     x = Drop.apply(x, group, dim)
-    x = Drop.apply(x, ax.comm_handle.depth_intra_layer_parallel_group, 0)
+    x = Drop.apply(x, ax.comm_handle.depth_intra_layer_parallel_group, batch_dim)
     return x
 
 
-def gather(x, transpose=False, dim=-1):
+def gather(x, transpose=False, dim=-1, batch_dim=0):
     if not transpose:
         group = ax.comm_handle.inner_intra_layer_parallel_group
     else:
         group = ax.comm_handle.outer_intra_layer_parallel_group
 
     x = Gather.apply(x, group, dim)
-    x = Gather.apply(x, ax.comm_handle.depth_intra_layer_parallel_group, 0)
+    x = Gather.apply(x, ax.comm_handle.depth_intra_layer_parallel_group, batch_dim)
     return x


### PR DESCRIPTION
For drop and gather wrt the depth dimension, Batch dim will not always be 0. For instance in Megatron the tensors are [s,b,h] and we want to drop/gather along the first dimension.