### PR TITLE
A context manager to optimize communication

### DIFF
--- a/axonn/communication.py
+++ b/axonn/communication.py
@@ -4,8 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import os
+
 try:
     from mpi4py import MPI
+
     MPI4PY = True
 except ImportError:
     MPI4PY = False
@@ -40,7 +42,8 @@ class communication_handle:
             G_intra_d (int): number of GPUs in the depth intra-layer parallel dimension
         """
         if not torch.distributed.is_initialized():
-            assert MPI4PY, "either install mpi4py and launch process via mpirun/srun or initialize torch.distributed outside axonn" 
+            assert MPI4PY, "either install mpi4py and launch via mpirun/srun"
+            "or initialize torch.distributed outside axonn"
             self.world_rank = MPI.COMM_WORLD.Get_rank()
             self.world_size = MPI.COMM_WORLD.Get_size()
         else:
@@ -89,8 +92,12 @@ class communication_handle:
                 assert self.p2p_mpi_comm.Get_size() == G_inter
             else:
                 self.p2p_mpi_comm = None
-                print("Warning: AxoNN's implementation of inter-layer parallelism (pipelining) requires mpi4py, which wasn't found." 
-                        "You will have to use an external implementation of pipeline parallelism.")
+                print(
+                    "Warning: AxoNN's implementation of inter-layer"
+                    "parallelism (pipelining) requires mpi4py, which wasn't found."
+                    "You will have to use an external implementation"
+                    "of pipeline parallelism."
+                )
         else:
             self.p2p_mpi_comm = None
 

--- a/axonn/intra_layer/__init__.py
+++ b/axonn/intra_layer/__init__.py
@@ -32,9 +32,10 @@ def gather(x, transpose=False, dim=-1, batch_dim=0):
 
 
 OVERLAP_COMM = False
+CACHE_WEIGHTS = False
 handles = []
 pending_grad_accumulations = []
-
+weights_cache = {}
 
 def register_handle(handle):
     # ToDo: This might be unnecesary since
@@ -65,11 +66,18 @@ def accumulate():
 
     pending_grad_accumulations = []
 
+def clear_weights_cache():
+    global weights_cache
+    weights_cache = {}
 
 @contextmanager
-def optimize_communication(*args, **kwargs):
-    global OVERLAP_COMM
+def optimize_communication(cache_weights=False, *args, **kwargs):
+    global OVERLAP_COMM, CACHE_WEIGHTS
     OVERLAP_COMM = True
+    if (not cache_weights) and (CACHE_WEIGHTS):
+        raise ValueError("Attempting to set cache_weights to False, when it was earlier set to True. This can lead to erroneous behaviours. Either always use cache_weights=False or cache_weights=True")
+    CACHE_WEIGHTS=cache_weights
+
     try:
         yield None
     finally:

--- a/axonn/intra_layer/__init__.py
+++ b/axonn/intra_layer/__init__.py
@@ -121,23 +121,25 @@ def retrieve_all_gathered_weight(weight):
 
 @contextmanager
 def optimize_communication(
-    overlap_all_reduce=True, overlap_reduce_scatter=False, cache_weights=False, overlap_all_gather=False, model=None, *args, **kwargs
+    overlap_all_reduce=True,
+    overlap_reduce_scatter=False,
+    cache_weights=False,
+    overlap_all_gather=False,
+    model=None,
+    *args,
+    **kwargs
 ):
-    global OVERLAP_ALL_REDUCE, OVERLAP_REDUCE_SCATTER, CACHE_WEIGHTS, ALL_GATHER_ITERATOR
+    global OVERLAP_ALL_REDUCE, OVERLAP_REDUCE_SCATTER, CACHE_WEIGHTS
+    global ALL_GATHER_ITERATOR
     OVERLAP_ALL_REDUCE = overlap_all_reduce
     OVERLAP_REDUCE_SCATTER = overlap_reduce_scatter
 
-    if (not cache_weights) and (CACHE_WEIGHTS):
-        raise ValueError(
-            "Attempting to set cache_weights to False, when it was earlier set to True." 
-            "This can lead to erroneous behaviour. Either always use cache_weights=False or cache_weights=True"
-        )
     CACHE_WEIGHTS = cache_weights
 
     if overlap_all_gather:
         if model is None:
             raise ValueError(
-                "You need to pass your model as an argument - " 
+                "You need to pass your model as an argument - "
                 "optimize_communication(...,model=model, ...)"
                 "if overlap_all_gather is True"
             )

--- a/axonn/intra_layer/__init__.py
+++ b/axonn/intra_layer/__init__.py
@@ -7,6 +7,7 @@ from .gradient_normalization import clip_grad_norm_  # noqa: F401
 
 from axonn import axonn as ax
 import torch
+import torch.distributed as dist
 
 
 def drop(x, transpose=False, dim=-1, batch_dim=0):
@@ -31,11 +32,14 @@ def gather(x, transpose=False, dim=-1, batch_dim=0):
     return x
 
 
-OVERLAP_COMM = False
+OVERLAP_REDUCE_SCATTER = False
+OVERLAP_ALL_REDUCE = False
 CACHE_WEIGHTS = False
+ALL_GATHER_ITERATOR = None
 handles = []
 pending_grad_accumulations = []
 weights_cache = {}
+
 
 def register_handle(handle):
     # ToDo: This might be unnecesary since
@@ -66,21 +70,88 @@ def accumulate():
 
     pending_grad_accumulations = []
 
+
 def clear_weights_cache():
     global weights_cache
     weights_cache = {}
 
+
+def trigger_async_all_gathers(model):
+    global weights_cache
+    for module in model.modules():
+        if isinstance(module, Linear):
+            weight = module.weight
+            if weight not in weights_cache:
+                # only trigger all gathers if not in cache
+                process_group = module.depth_group
+                world_size = dist.get_world_size(process_group)
+                if world_size == 1:
+                    all_gathered_weight = weight
+                    handle = None
+                else:
+                    assert weight.ndim == 1
+                    output_shape = weight.shape[0] * world_size
+                    all_gathered_weight = torch.empty(
+                        output_shape, dtype=weight.dtype, device=weight.device
+                    )
+                    handle = dist.all_gather_into_tensor(
+                        all_gathered_weight, weight, group=process_group, async_op=True
+                    )
+                weights_cache[weight] = [all_gathered_weight, handle]
+            yield
+
+
+def enqueue_next_all_gather():
+    global ALL_GATHER_ITERATOR
+    assert ALL_GATHER_ITERATOR is not None
+    try:
+        next(ALL_GATHER_ITERATOR)
+    except StopIteration:
+        pass
+
+
+def retrieve_all_gathered_weight(weight):
+    global CACHE_WEIGHTS, ALL_GATHER_ITERATOR
+    assert weight in weights_cache
+    all_gathered_weight, handle = weights_cache[weight]
+    if ALL_GATHER_ITERATOR is not None:
+        enqueue_next_all_gather()
+    return all_gathered_weight, handle
+
+
 @contextmanager
-def optimize_communication(cache_weights=False, *args, **kwargs):
-    global OVERLAP_COMM, CACHE_WEIGHTS
-    OVERLAP_COMM = True
+def optimize_communication(
+    overlap_all_reduce=True, overlap_reduce_scatter=False, cache_weights=False, overlap_all_gather=False, model=None, *args, **kwargs
+):
+    global OVERLAP_ALL_REDUCE, OVERLAP_REDUCE_SCATTER, CACHE_WEIGHTS, ALL_GATHER_ITERATOR
+    OVERLAP_ALL_REDUCE = overlap_all_reduce
+    OVERLAP_REDUCE_SCATTER = overlap_reduce_scatter
+
     if (not cache_weights) and (CACHE_WEIGHTS):
-        raise ValueError("Attempting to set cache_weights to False, when it was earlier set to True. This can lead to erroneous behaviours. Either always use cache_weights=False or cache_weights=True")
-    CACHE_WEIGHTS=cache_weights
+        raise ValueError(
+            "Attempting to set cache_weights to False, when it was earlier set to True." 
+            "This can lead to erroneous behaviour. Either always use cache_weights=False or cache_weights=True"
+        )
+    CACHE_WEIGHTS = cache_weights
+
+    if overlap_all_gather:
+        if model is None:
+            raise ValueError(
+                "You need to pass your model as an argument - " 
+                "optimize_communication(...,model=model, ...)"
+                "if overlap_all_gather is True"
+            )
+        assert (
+            cache_weights
+        ), "all gathers can only be overlapped if cache_weights is True"
+        ALL_GATHER_ITERATOR = trigger_async_all_gathers(model)
+        enqueue_next_all_gather()
 
     try:
         yield None
     finally:
         clear_handles()
         accumulate()
-        OVERLAP_COMM = False
+        OVERLAP_ALL_REDUCE = False
+        OVERLAP_REDUCE_SCATTER = False
+        ALL_GATHER_ITERATOR = None

--- a/axonn/intra_layer/__init__.py
+++ b/axonn/intra_layer/__init__.py
@@ -6,6 +6,7 @@ from .communication import Drop, Gather
 from .gradient_normalization import clip_grad_norm_  # noqa: F401
 
 from axonn import axonn as ax
+import torch
 
 
 def drop(x, transpose=False, dim=-1, batch_dim=0):
@@ -30,52 +31,48 @@ def gather(x, transpose=False, dim=-1, batch_dim=0):
     return x
 
 
-OVERLAP_COMM=False
+OVERLAP_COMM = False
 handles = []
 pending_grad_accumulations = []
 
+
 def register_handle(handle):
+    # ToDo: This might be unnecesary since
+    # we are calling synchronize in clear_handles
     global handles
     handles.append(handle)
 
+
 def clear_handles():
     global handles
-    for handle in handles:
-        handle.wait()
+    torch.cuda.synchronize()
     handles = []
 
-def accumulate_later(param, grad, main_grad):
+
+def accumulate_later(param, grad):
     global pending_grad_accumulations
+    pending_grad_accumulations.append([param, grad])
 
-    pending_grad_accumulations.append([param, grad, main_grad])
 
+@torch.no_grad()
 def accumulate():
     global pending_grad_accumulations
-    for param, grad, main_grad in pending_grad_accumulations:
-        if main_grad is None:
+    for param, grad in pending_grad_accumulations:
+        if param.grad is None:
             param.grad = grad
         else:
-            param.grad = main_grad.data.add_(grad)
+            param.grad.add_(grad)
 
     pending_grad_accumulations = []
 
-@contextmanager
-def optimize_communication(enabled : bool = True):
-    ## no sync -> True, cache weights, prevent extra all-gathers
-    ## else -> clear weights
-    global OVERLAP_COMM
-    if not enabled:
-        try:
-            yield None
-        finally:
-            return 
 
-    OVERLAP_COMM=True
+@contextmanager
+def optimize_communication(*args, **kwargs):
+    global OVERLAP_COMM
+    OVERLAP_COMM = True
     try:
         yield None
     finally:
         clear_handles()
         accumulate()
-        OVERLAP_COMM=False
-
-
+        OVERLAP_COMM = False

--- a/axonn/intra_layer/__init__.py
+++ b/axonn/intra_layer/__init__.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from .fully_connected import Linear  # noqa: F401
 from .conv import Conv2d as Tensor_Parallel_Conv2d  # noqa: F401
 
@@ -27,3 +28,54 @@ def gather(x, transpose=False, dim=-1, batch_dim=0):
     x = Gather.apply(x, group, dim)
     x = Gather.apply(x, ax.comm_handle.depth_intra_layer_parallel_group, batch_dim)
     return x
+
+
+OVERLAP_COMM=False
+handles = []
+pending_grad_accumulations = []
+
+def register_handle(handle):
+    global handles
+    handles.append(handle)
+
+def clear_handles():
+    global handles
+    for handle in handles:
+        handle.wait()
+    handles = []
+
+def accumulate_later(param, grad, main_grad):
+    global pending_grad_accumulations
+
+    pending_grad_accumulations.append([param, grad, main_grad])
+
+def accumulate():
+    global pending_grad_accumulations
+    for param, grad, main_grad in pending_grad_accumulations:
+        if main_grad is None:
+            param.grad = grad
+        else:
+            param.grad = main_grad.data.add_(grad)
+
+    pending_grad_accumulations = []
+
+@contextmanager
+def optimize_communication(enabled : bool = True):
+    ## no sync -> True, cache weights, prevent extra all-gathers
+    ## else -> clear weights
+    global OVERLAP_COMM
+    if not enabled:
+        try:
+            yield None
+        finally:
+            return 
+
+    OVERLAP_COMM=True
+    try:
+        yield None
+    finally:
+        clear_handles()
+        accumulate()
+        OVERLAP_COMM=False
+
+

--- a/axonn/intra_layer/fully_connected.py
+++ b/axonn/intra_layer/fully_connected.py
@@ -203,7 +203,7 @@ class Linear(torch.nn.Module):
         # gather weights from depth parallel group
         # reduce scatter in the backward pass
         weight = ForwardGather_BackwardReduceScatter.apply(
-            self.weight, self.depth_group, 0, axonn.intra_layer.OVERLAP_COMM
+            self.weight, self.depth_group, 0, axonn.intra_layer.OVERLAP_COMM, axonn.intra_layer.CACHE_WEIGHTS
         ).reshape(self.local_out_features, self.local_in_features)
 
         if not self.transpose:

--- a/axonn/intra_layer/fully_connected.py
+++ b/axonn/intra_layer/fully_connected.py
@@ -203,7 +203,11 @@ class Linear(torch.nn.Module):
         # gather weights from depth parallel group
         # reduce scatter in the backward pass
         weight = ForwardGather_BackwardReduceScatter.apply(
-            self.weight, self.depth_group, 0, axonn.intra_layer.OVERLAP_COMM, axonn.intra_layer.CACHE_WEIGHTS
+            self.weight,
+            self.depth_group,
+            0,
+            axonn.intra_layer.OVERLAP_REDUCE_SCATTER,
+            axonn.intra_layer.CACHE_WEIGHTS,
         ).reshape(self.local_out_features, self.local_in_features)
 
         if not self.transpose:
@@ -215,7 +219,7 @@ class Linear(torch.nn.Module):
                 weight,
                 self.inner_group,
                 self.outer_group,
-                axonn.intra_layer.OVERLAP_COMM,
+                axonn.intra_layer.OVERLAP_ALL_REDUCE,
                 False,
             )
             if gather_output:
@@ -231,7 +235,7 @@ class Linear(torch.nn.Module):
                 weight,
                 self.outer_group,
                 self.inner_group,
-                axonn.intra_layer.OVERLAP_COMM,
+                axonn.intra_layer.OVERLAP_ALL_REDUCE,
                 False,
             )
             if gather_output:


### PR DESCRIPTION
If the forward and backward pass are done within this context, axonn overlaps all the tensor parallel communication in the backward pass (reduce scatters for depth tensor parallelism and all reduces for row and column tensor parallelism)

Example of Usage

```
for batch, label in loader():
     with axonn.intra_layer.optimize_communication():
         out = model(batch)
         out.backward() # enqueues reduce scatters asynchronously
         # gradients are not ready

     # as soon as we exit the context all reduce scatters are synchronized and the gradients 
     # are ready
     optimizer.step() # important to run OUTSIDE context.
```


