### PR TITLE
added automatic_parallelism

### DIFF
--- a/axonn/__init__.py
+++ b/axonn/__init__.py
@@ -2,4 +2,4 @@
 # See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-from . import models  # noqa: F401
+#from . import models  # noqa: F401

--- a/axonn/__init__.py
+++ b/axonn/__init__.py
@@ -2,4 +2,4 @@
 # See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-#from . import models  # noqa: F401
+# from . import models  # noqa: F401

--- a/axonn/intra_layer/__init__.py
+++ b/axonn/intra_layer/__init__.py
@@ -8,7 +8,7 @@ from .gradient_normalization import clip_grad_norm_  # noqa: F401
 from axonn import axonn as ax
 import torch
 import torch.distributed as dist
-from .automatic_parallelism import auto_parallellize
+from .automatic_parallelism import auto_parallellize  # noqa: F401
 
 
 def drop(

--- a/axonn/intra_layer/__init__.py
+++ b/axonn/intra_layer/__init__.py
@@ -8,6 +8,7 @@ from .gradient_normalization import clip_grad_norm_  # noqa: F401
 from axonn import axonn as ax
 import torch
 import torch.distributed as dist
+from .automatic_parallelism import auto_parallellize
 
 
 def drop(

--- a/axonn/intra_layer/__init__.py
+++ b/axonn/intra_layer/__init__.py
@@ -8,7 +8,7 @@ from .gradient_normalization import clip_grad_norm_  # noqa: F401
 from axonn import axonn as ax
 import torch
 import torch.distributed as dist
-from .automatic_parallelism import auto_parallellize  # noqa: F401
+from .automatic_parallelism import auto_parallelize  # noqa: F401
 
 
 def drop(

--- a/axonn/intra_layer/automatic_parallelism.py
+++ b/axonn/intra_layer/automatic_parallelism.py
@@ -1,20 +1,20 @@
 import torch.nn as nn
-import sys
-import os
 from axonn import axonn as ax
 from axonn.intra_layer import Linear
 
-sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-
-def auto_parallellize(model):
+def auto_parallelize(model):
     G_row = ax.config.G_intra_r
     G_col = ax.config.G_intra_c
-    G_depth = ax.config.G_intra_r
+    G_depth = ax.config.G_intra_d
+    # Iterate through all modules in the model
     for name, module in model.named_modules():
         if isinstance(module, nn.Module):
+            # Iterate through all child modules of each module
             for attr_name, attr_module in module.named_children():
+                # Check if the module is a linear layer
                 if isinstance(attr_module, nn.Linear):
+                    # Check if layer is "parallelizable"
                     if (
                         (attr_module.out_features % G_row == 0)
                         and (attr_module.in_features % G_col == 0)
@@ -25,6 +25,7 @@ def auto_parallellize(model):
                             == 0
                         )
                     ):
+                        # Replace the linear layer with Axonn's linear layer
                         setattr(
                             module,
                             attr_name,

--- a/axonn/intra_layer/automatic_parallelism.py
+++ b/axonn/intra_layer/automatic_parallelism.py
@@ -1,13 +1,10 @@
-import torch
 import torch.nn as nn
-import torchvision
 import sys
 import os
-from torchvision import transforms
-import numpy as np
 from axonn import axonn as ax
 from axonn.intra_layer import Linear
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 
 def auto_parallellize(model):
@@ -18,8 +15,19 @@ def auto_parallellize(model):
         if isinstance(module, nn.Module):
             for attr_name, attr_module in module.named_children():
                 if isinstance(attr_module, nn.Linear):
-                    if (attr_module.out_features % G_row == 0) and \
-                       (attr_module.in_features % G_col == 0) and \
-                       ((attr_module.out_features * attr_module.in_features) / (G_row * G_col) % G_depth == 0):
-                        setattr(module, attr_name, Linear(attr_module.in_features, attr_module.out_features))
+                    if (
+                        (attr_module.out_features % G_row == 0)
+                        and (attr_module.in_features % G_col == 0)
+                        and (
+                            (attr_module.out_features * attr_module.in_features)
+                            / (G_row * G_col)
+                            % G_depth
+                            == 0
+                        )
+                    ):
+                        setattr(
+                            module,
+                            attr_name,
+                            Linear(attr_module.in_features, attr_module.out_features),
+                        )
     return model

--- a/axonn/intra_layer/automatic_parallelism.py
+++ b/axonn/intra_layer/automatic_parallelism.py
@@ -1,0 +1,25 @@
+import torch
+import torch.nn as nn
+import torchvision
+import sys
+import os
+from torchvision import transforms
+import numpy as np
+from axonn import axonn as ax
+from axonn.intra_layer import Linear
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+
+def auto_parallellize(model):
+    G_row = ax.config.G_intra_r
+    G_col = ax.config.G_intra_c
+    G_depth = ax.config.G_intra_r
+    for name, module in model.named_modules():
+        if isinstance(module, nn.Module):
+            for attr_name, attr_module in module.named_children():
+                if isinstance(attr_module, nn.Linear):
+                    if (attr_module.out_features % G_row == 0) and \
+                       (attr_module.in_features % G_col == 0) and \
+                       ((attr_module.out_features * attr_module.in_features) / (G_row * G_col) % G_depth == 0):
+                        setattr(module, attr_name, Linear(attr_module.in_features, attr_module.out_features))
+    return model


### PR DESCRIPTION
The `auto_parallelize` function automatically detects linear layers in a neural network model and substitutes them with AxoNN’s parallel linear layers if the linear layers adhere to the intra-layer grid configuration criteria. To utilize this functionality, users must import `auto_parallelize` from `axonn.intra_layer` and provide the target model as an argument to this function. Upon execution, the function will parallelize the linear layers within the model and return the modified model.