### PR TITLE
Supporting init_module, load/save checkpoint

### DIFF
--- a/axonn/intra_layer/__init__.py
+++ b/axonn/intra_layer/__init__.py
@@ -184,6 +184,7 @@ def optimize_communication(
     finally:
         clear_handles()
         accumulate()
+        clear_weights_cache()
         OVERLAP_ALL_REDUCE = False
         OVERLAP_REDUCE_SCATTER = False
         ALL_GATHER_ITERATOR = None

--- a/axonn/lightning/axonn_strategy.py
+++ b/axonn/lightning/axonn_strategy.py
@@ -44,10 +44,11 @@ from axonn.intra_layer import (
     clip_grad_norm_,
     no_grad_sync,
     auto_parallelize,
-    optimize_communication
+    optimize_communication,
 )
 from axonn.checkpoint import get_prefix_for_checkpoint
 import os
+
 
 class AxonnStrategy(ParallelStrategy):
     def __init__(
@@ -220,7 +221,9 @@ class AxonnStrategy(ParallelStrategy):
     def load_checkpoint(
         self,
         path: _PATH,
-        state: Optional[Union[Module, Optimizer, Dict[str, Union[Module, Optimizer, Any]]]] = None,
+        state: Optional[
+            Union[Module, Optimizer, Dict[str, Union[Module, Optimizer, Any]]]
+        ] = None,
         strict: bool = True,
     ) -> Dict[str, Any]:
         checkpoint_prefix = get_prefix_for_checkpoint()
@@ -238,13 +241,17 @@ class AxonnStrategy(ParallelStrategy):
         filter: Optional[Dict[str, Callable[[str, Any], bool]]] = None,
     ) -> None:
         if torch.distributed.get_rank(ax.comm_handle.data_parallel_group) == 0:
-            # different prefix for different tensor parallel ranks 
+            # different prefix for different tensor parallel ranks
             checkpoint_prefix = get_prefix_for_checkpoint()
             directory, filename = os.path.split(path)
             filename = checkpoint_prefix + "_" + filename
-            state = self._convert_stateful_objects_in_state(state, filter=(filter or {}))
+            state = self._convert_stateful_objects_in_state(
+                state, filter=(filter or {})
+            )
             path = os.path.join(directory, filename)
-            self.checkpoint_io.save_checkpoint(checkpoint=state, path=path, storage_options=storage_options)
+            self.checkpoint_io.save_checkpoint(
+                checkpoint=state, path=path, storage_options=storage_options
+            )
 
     @override
     def clip_gradients_norm(
@@ -273,11 +280,14 @@ class AxonnStrategy(ParallelStrategy):
     def module_sharded_context(self) -> ContextManager:
         return auto_parallelize()
 
-    def optimize_communication(self, module: Module, enabled: bool = True) -> ContextManager:
+    def optimize_communication(
+        self, module: Module, enabled: bool = True
+    ) -> ContextManager:
         if not enabled:
             return nullcontext()
         else:
             return optimize_communication(True, True, True, module)
+
 
 class _AxoNNBackwardSyncControl(_BackwardSyncControl):
     @override

--- a/axonn/lightning/axonn_strategy.py
+++ b/axonn/lightning/axonn_strategy.py
@@ -226,9 +226,10 @@ class AxonnStrategy(ParallelStrategy):
         ] = None,
         strict: bool = True,
     ) -> Dict[str, Any]:
+        # different prefix for different tensor parallel ranks
         checkpoint_prefix = get_prefix_for_checkpoint()
         directory, filename = os.path.split(path)
-        filename = checkpoint_prefix + "_" + filename
+        directory = os.path.join(directory, checkpoint_prefix)
         path = os.path.join(directory, filename)
         return super().load_checkpoint(path, state, strict)
 
@@ -244,7 +245,7 @@ class AxonnStrategy(ParallelStrategy):
             # different prefix for different tensor parallel ranks
             checkpoint_prefix = get_prefix_for_checkpoint()
             directory, filename = os.path.split(path)
-            filename = checkpoint_prefix + "_" + filename
+            directory = os.path.join(directory, checkpoint_prefix)
             state = self._convert_stateful_objects_in_state(
                 state, filter=(filter or {})
             )

--- a/axonn/lightning/axonn_strategy.py
+++ b/axonn/lightning/axonn_strategy.py
@@ -42,8 +42,9 @@ from axonn.intra_layer import (
     sync_gradients_depth_parallel,
     clip_grad_norm_,
     no_grad_sync,
-    auto_parallelize
+    auto_parallelize,
 )
+
 
 class AxonnStrategy(ParallelStrategy):
     def __init__(

--- a/axonn/lightning/axonn_strategy.py
+++ b/axonn/lightning/axonn_strategy.py
@@ -42,8 +42,8 @@ from axonn.intra_layer import (
     sync_gradients_depth_parallel,
     clip_grad_norm_,
     no_grad_sync,
+    auto_parallelize
 )
-
 
 class AxonnStrategy(ParallelStrategy):
     def __init__(
@@ -212,6 +212,7 @@ class AxonnStrategy(ParallelStrategy):
         if self.G_data > 1:
             sync_gradients_data_parallel(module, mean=True)
 
+    @override
     def save_checkpoint(
         self,
         *args,
@@ -222,6 +223,7 @@ class AxonnStrategy(ParallelStrategy):
             "AxoNN strategy. Use axonn.save instead."
         )
 
+    @override
     def load_checkpoint(
         self,
         *args,
@@ -232,6 +234,7 @@ class AxonnStrategy(ParallelStrategy):
             " AxoNN strategy. Use axonn.load instead."
         )
 
+    @override
     def clip_gradients_norm(
         self,
         module: Module,
@@ -249,6 +252,14 @@ class AxonnStrategy(ParallelStrategy):
             error_if_nonfinite=error_if_nonfinite,
         )
         return grad_norm
+
+    @override
+    def module_init_context(self, empty_init: Optional[bool] = None):
+        return self.module_sharded_context()
+
+    @override
+    def module_sharded_context(self) -> ContextManager:
+        return auto_parallelize()
 
 
 class _AxoNNBackwardSyncControl(_BackwardSyncControl):


### PR DESCRIPTION
`init_module` - is one of the official fabric APIs to parallelize a model. This is supposed to return a context manager, so it meshes nicely with our auto_parallelize. 

Other stuff - loading and saving checkpoints.