### PR TITLE
make no-grad-sync yield None

### DIFF
--- a/axonn/intra_layer/__init__.py
+++ b/axonn/intra_layer/__init__.py
@@ -196,6 +196,7 @@ def no_grad_sync():
     old_val = NO_GRADIENT_SYNC
     try:
         NO_GRADIENT_SYNC = True
+        yield None
     finally:
         NO_GRADIENT_SYNC = old_val
 


### PR DESCRIPTION
The expected behavior of a context manager is to yield something. 