### PR TITLE
Autotuning - initial infra + a small optimization for pure depth tp

### DIFF
--- a/axonn/communication.py
+++ b/axonn/communication.py
@@ -15,6 +15,7 @@ except ImportError:
     MPI4PY = False
 import torch
 import numpy as np
+from typing import Sequence, Optional
 
 
 class communication_handle:
@@ -160,11 +161,20 @@ class communication_handle:
             self.inner_intra_layer_parallel_group,
             self.outer_intra_layer_parallel_group,
             self.depth_intra_layer_parallel_group,
-        ) = self.get_intra_layer_groups(G_intra_r, G_intra_c, G_intra_d)
+        ) = self.get_intra_layer_groups()
 
-    def get_intra_layer_groups(self, G_intra_r, G_intra_c, G_intra_d):
+    def get_intra_layer_groups(
+        self, tensor_parallel_dims: Optional[Sequence[int]] = None
+    ):
         G_inter, G_data, G_intra = self.G_inter, self.G_data, self.G_intra
-
+        if tensor_parallel_dims is None:
+            G_intra_r, G_intra_c, G_intra_d = (
+                self.G_intra_r,
+                self.G_intra_c,
+                self.G_intra_d,
+            )
+        else:
+            G_intra_r, G_intra_c, G_intra_d = tensor_parallel_dims
         # first check if these communicators have already
         # been created
         group_key = (G_intra_r, G_intra_c, G_intra_d)

--- a/axonn/intra_layer/automatic_parallelism.py
+++ b/axonn/intra_layer/automatic_parallelism.py
@@ -31,9 +31,20 @@ def is_parallelizable_embedding(num_embeddings, embedding_dim):
 
 
 class patched_linear:
-    def __new__(cls, in_features, out_features, bias=True, device=None, dtype=None):
+    def __new__(
+        cls,
+        in_features,
+        out_features,
+        *args,
+        bias=True,
+        device=None,
+        dtype=None,
+        **kwargs,
+    ):
         if is_parallelizable_linear(in_features, out_features):
-            parallel_layer = Linear(in_features, out_features, bias=bias)
+            parallel_layer = Linear(
+                in_features, out_features, bias=bias, *args, **kwargs
+            )
             if device is not None:
                 parallel_layer = parallel_layer.to(device)
             if dtype is not None:
@@ -41,7 +52,7 @@ class patched_linear:
             return parallel_layer
         else:
             sequential_layer = reference_to_original_linear_class(
-                in_features, out_features, bias=bias
+                in_features, out_features, bias=bias, *args, **kwargs
             )
             if device is not None:
                 sequential_layer = sequential_layer.to(device)


### PR DESCRIPTION
Building the initial infra for autotuning. FC layers can accept a `tensor_parallel_dims` argument and create a tp decomposition separate from the global tp decomposition. 

Noticed that the extra non expert communication takes a considerable amount of time even for pure depth-tp. Note that in this case we aren't actually doing any communication so it's basically the setup costs to launch identity kernels. I simply disabled it.